### PR TITLE
Simplify git checkout

### DIFF
--- a/.github/workflows/stable-docs.yml
+++ b/.github/workflows/stable-docs.yml
@@ -52,13 +52,9 @@ jobs:
         # Check if the list of files is non-empty
         if [[ -n "$FILES" ]]; then
           # Checkout those files to the stable branch to over-write with their contents
-          for FILE in $FILES; do
-            git checkout ${{ github.sha }} -- $FILE
-          done
-          git add docs/
+          git checkout ${{ github.sha }} -- $FILES
           git commit -m "Doc changes from ${{ github.sha }}"
           git push origin stable
         else
           echo "No changes to docs/ in this commit"
-          exit 0
         fi


### PR DESCRIPTION
Hi! Thanks for [your very thoughtful blog post](https://til.simonwillison.net/readthedocs/stable-docs)! Since [we're considering using your workflow](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4798), I noticed a couple of things and thought I'd suggest them upstream:

- `git checkout [COMMIT] -- [FILES]` allows multiple files after the `--`, and the unquoted `$FILES` should get the same whitespace splitting this way as with the original `for FILE in $FILES`. (Here we're hoping that no files contain whitespace in their names, which is not great for security, but no worse than the original.)
- When `[COMMIT]` is specified (as it is here), the index is also updated, so there's no need for a separate `git add`.

Having an `exit 0` as the last line, especially after an `echo` which shouldn't fail, seems redundant.